### PR TITLE
Add CloudFront cache invalidation to deploy workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -29,3 +29,5 @@ jobs:
           aws-region: us-west-2
 
       - run: aws s3 sync dist/cql-runner s3://cql-runner.dataphoria.org --delete
+
+      - run: aws cloudfront create-invalidation --distribution-id ${{ secrets.CLOUDFRONT_DISTRIBUTION_ID }} --paths "/*"


### PR DESCRIPTION
  - Add automatic CloudFront cache invalidation step after S3 sync in GitHub Actions deploy workflow
  - Prevents stale content from being served after deployments